### PR TITLE
Add external module references

### DIFF
--- a/modviz/cli.py
+++ b/modviz/cli.py
@@ -11,6 +11,9 @@ def parse_arguments(args=None):
     parser.add_argument("-o", dest="target", help="the output file (default: stdout)")
     parser.add_argument("-f", dest="fold_paths", nargs="*", help="paths that need to be folded up ('vendor' dirs, for example)")
     parser.add_argument("-e", dest="exclude_paths", nargs="*", help="paths that should be excluded from the output")
+    parser.add_argument("-r", dest="req_filename", help="requirements filename (default: requirements.txt)")
+    parser.add_argument("-x", dest="show_external", action="store_true", help="show external modules")
+    parser.set_defaults(show_external=False)
     if args is None:  # pragma: no coverage
         return parser.parse_args()
     return parser.parse_args(args)
@@ -41,7 +44,8 @@ def main():  # pragma: no coverage
         sys.stderr.write("error: invalid fold path '{}'\n".format(e.message))
         return 1
 
-    result = viz(arguments.path, arguments.fold_paths, arguments.exclude_paths)
+    result = viz(arguments.path, arguments.fold_paths, arguments.exclude_paths,
+                 show_external=arguments.show_external)
     if arguments.target:
         with open(arguments.target, "w") as f:
             f.write(result)

--- a/modviz/cli.py
+++ b/modviz/cli.py
@@ -11,7 +11,6 @@ def parse_arguments(args=None):
     parser.add_argument("-o", dest="target", help="the output file (default: stdout)")
     parser.add_argument("-f", dest="fold_paths", nargs="*", help="paths that need to be folded up ('vendor' dirs, for example)")
     parser.add_argument("-e", dest="exclude_paths", nargs="*", help="paths that should be excluded from the output")
-    parser.add_argument("-r", dest="req_filename", help="requirements filename (default: requirements.txt)")
     parser.add_argument("-x", dest="show_external", action="store_true", help="show external modules")
     parser.set_defaults(show_external=False)
     if args is None:  # pragma: no coverage

--- a/tests/test_finder.py
+++ b/tests/test_finder.py
@@ -19,3 +19,27 @@ def test_package_relative_from():
     finder = ReferenceFinder(modules, modules[1])
     finder.visit(ast.parse(source))
     assert finder.references == set([Module("/", "foo/bar.py")])
+
+def test_find_external():
+    modules = [Module("/", "foo/bar.py")]
+    source = "import baz"
+    finder = ReferenceFinder(modules, modules[0])
+    finder.visit(ast.parse(source))
+    assert finder.ext_references == set([Module("/", "baz.py")])
+
+def test_find_external_dot():
+    modules = [Module("/", "foo/bar.py")]
+    source = "import baz.bazz"
+    finder = ReferenceFinder(modules, modules[0])
+    finder.visit(ast.parse(source))
+    assert finder.ext_references == set([Module("/", "baz/bazz.py")])
+
+def test_find_external_from_import():
+    modules = [Module("/", "foo/bar.py")]
+    source = "from baz import bazz"
+    finder = ReferenceFinder(modules, modules[0])
+    finder.visit(ast.parse(source))
+    assert finder.ext_references == set([
+        Module("/", "baz.py"),
+        Module("/", "baz/bazz.py")
+    ])


### PR DESCRIPTION
This option is useful if one does not want to fold vendor or lib folders yet want to see how external modules are imported.

Use -x to include external references.
